### PR TITLE
correct check for cssRules property on styleSheets

### DIFF
--- a/src/embedWebFonts.ts
+++ b/src/embedWebFonts.ts
@@ -5,14 +5,14 @@ function getCssRules(styleSheets: CSSStyleSheet[]): CSSStyleRule[] {
   const ret: CSSStyleRule[] = []
 
   styleSheets.forEach((sheet) => {
-    try {
-      if (sheet.cssRules) {
+    if (sheet.hasOwnProperty('cssRules')) {
+      try {
         toArray<CSSStyleRule>(sheet.cssRules).forEach((item: CSSStyleRule) => {
           ret.push(item)
         })
+      } catch (e) {
+        console.log(`Error while reading CSS rules from ${sheet.href}`, e.toString())
       }
-    } catch (e) {
-      console.log(`Error while reading CSS rules from ${sheet.href}`, e.toString())
     }
   })
 


### PR DESCRIPTION
I don't know if anyone created an issue on the repo, but I was able to find this question on SO: https://stackoverflow.com/questions/50977367/htmltoimage-chrome-64-securityerror-failed-to-read-the-cssrules-property-from
If it was already reported, please link it accordingly.

Cheers!