### PR TITLE
Add ability to inline external web fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-image",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Generates an image from a DOM node using HTML5 canvas.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -21,10 +21,16 @@
     "vector",
     "svg"
   ],
-  "author": {
-    "name": "bubkooo",
-    "email": "bubkoo.wy@gmail.com"
-  },
+  "authors": [
+    {
+      "name": "bubkooo",
+      "email": "bubkoo.wy@gmail.com"
+    },
+    {
+      "name": "OiNutter",
+      "email": "will@oinutter.co.uk"
+    }
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/embedWebFonts.ts
+++ b/src/embedWebFonts.ts
@@ -1,22 +1,137 @@
 import { toArray } from './utils'
 import embedResources, { shouldEmbed } from './embedResources'
 
-function getCssRules(styleSheets: CSSStyleSheet[]): CSSStyleRule[] {
-  const ret: CSSStyleRule[] = []
+function parseCSS(source:string) {
 
+  if (source === undefined) {
+    return []
+  }
+
+  let cssText = source
+  const css = []
+  const cssKeyframeRegex = '((@.*?keyframes [\\s\\S]*?){([\\s\\S]*?}\\s*?)})'
+  const combinedCSSRegex = '((\\s*?(?:\\/\\*[\\s\\S]*?\\*\\/)?\\s*?@media[\\s\\S]'
+  + '*?){([\\s\\S]*?)}\\s*?})|(([\\s\\S]*?){([\\s\\S]*?)})' // to match css & media queries together
+  const cssCommentsRegex = new RegExp('(\\/\\*[\\s\\S]*?\\*\\/)', 'gi')
+
+  // strip out comments
+  cssText = cssText.replace(cssCommentsRegex, '')
+
+  const keyframesRegex = new RegExp(cssKeyframeRegex, 'gi')
+  let arr
+  while (true) {
+    arr = keyframesRegex.exec(cssText)
+    if (arr === null) {
+      break
+    }
+    css.push(arr[0])
+  }
+  cssText = cssText.replace(keyframesRegex, '')
+
+  // unified regex
+  const unified = new RegExp(combinedCSSRegex, 'gi')
+  while (true) {
+    arr = unified.exec(cssText)
+    if (arr === null) {
+      break
+    }
+    css.push(arr[0])
+  }
+
+  return css
+}
+
+function fetchCSS(url: string, sheet: StyleSheet): Promise<any> {
+  return fetch(url).then((res: Response) => {
+    return {
+      url,
+      cssText:res.text(),
+    }
+  },                     (e) => {
+    console.log('ERROR FETCHING CSS: ', e.toString())
+  })
+}
+
+function embedFonts(data: any): Promise<string> {
+  return data.cssText.then((resolved: string) => {
+    let cssText = resolved
+    const fontLocations = cssText.match(/url\([^)]+\)/g) || []
+    const fontLoadedPromises = fontLocations.map((location: string) => {
+      let url = location.replace(/url\(([^]+)\)/g, '$1')
+      if (!url.startsWith('https://')) {
+        const source = data.url
+        console.log('source', source.substr(0, source.lastIndexOf('/')), url)
+        url = new URL(url, source).href
+      }
+      console.log('URL', url)
+      return new Promise((resolve, reject) => {
+        fetch(url)
+          .then((res: Response) => res.blob())
+          .then((blob) => {
+            const reader = new FileReader()
+            reader.addEventListener('load', (res: Event) => {
+              // Side Effect
+              cssText = cssText.replace(location, `url(${reader.result})`)
+              resolve([location, reader.result])
+            })
+            reader.readAsDataURL(blob)
+          })
+          .catch(reject)
+      })
+    })
+    return Promise.all(fontLoadedPromises).then(() => cssText)
+  })
+
+}
+
+function getCssRules(styleSheets: CSSStyleSheet[]): Promise<CSSStyleRule[]> {
+  const ret: CSSStyleRule[] = []
+  const promises: Promise<number | void>[] = []
+
+  // First loop inlines imports
   styleSheets.forEach((sheet) => {
-    if (sheet.hasOwnProperty('cssRules')) {
+    if ('cssRules' in sheet) {
       try {
-        toArray<CSSStyleRule>(sheet.cssRules).forEach((item: CSSStyleRule) => {
-          ret.push(item)
+        toArray<CSSRule>(sheet.cssRules).forEach((item: CSSRule) => {
+          if (item.type === CSSRule.IMPORT_RULE) {
+            promises.push(fetchCSS((item as CSSImportRule).href, sheet)
+              .then(embedFonts)
+              .then((cssText) => {
+                const parsed = parseCSS(cssText)
+                parsed.forEach((rule:any) => {
+                  sheet.insertRule(rule, sheet.cssRules.length)
+                })
+              })
+              .catch((e) => {
+                console.log('Error loading remote css', e.toString())
+              }))
+          }
         })
       } catch (e) {
-        console.log(`Error while reading CSS rules from ${sheet.href}`, e.toString())
+        console.log('Error inlining remote css file', e.toString())
       }
     }
   })
 
-  return ret
+  return Promise
+    .all(promises)
+    .then(() => {
+
+      // Second loop parses rules
+      styleSheets.forEach((sheet) => {
+        if ('cssRules' in sheet) {
+          try {
+            toArray<CSSStyleRule>(sheet.cssRules).forEach((item: CSSStyleRule) => {
+              ret.push(item)
+            })
+          } catch (e) {
+            console.log(`Error while reading CSS rules from ${sheet.href}`, e.toString())
+          }
+        }
+      })
+
+      return ret
+    })
 }
 
 function getWebFontRules(cssRules: CSSStyleRule[]): CSSStyleRule[] {

--- a/src/embedWebFonts.ts
+++ b/src/embedWebFonts.ts
@@ -96,7 +96,7 @@ function getCssRules(styleSheets: CSSStyleSheet[]): Promise<CSSStyleRule[]> {
           if (item.type === CSSRule.IMPORT_RULE) {
             promises.push(fetchCSS((item as CSSImportRule).href, sheet)
               .then(embedFonts)
-              .then((cssText) => {
+              .then((cssText: any) => {
                 const parsed = parseCSS(cssText)
                 parsed.forEach((rule:any) => {
                   sheet.insertRule(rule, sheet.cssRules.length)
@@ -108,6 +108,20 @@ function getCssRules(styleSheets: CSSStyleSheet[]): Promise<CSSStyleRule[]> {
           }
         })
       } catch (e) {
+        const inline = styleSheets.find(a => a.href === null) || document.styleSheets[0]
+        if (sheet.href != null) {
+          promises.push(fetchCSS(sheet.href, inline)
+            .then(embedFonts)
+            .then((cssText: any) => {
+              const parsed = parseCSS(cssText)
+              parsed.forEach((rule:any) => {
+                (inline as CSSStyleSheet).insertRule(rule, sheet.cssRules.length)
+              })
+            })
+            .catch((e) => {
+              console.log('Error loading remote stylesheet', e.toString())
+            }))
+        }
         console.log('Error inlining remote css file', e.toString())
       }
     }

--- a/src/embedWebFonts.ts
+++ b/src/embedWebFonts.ts
@@ -60,10 +60,8 @@ function embedFonts(data: any): Promise<string> {
       let url = location.replace(/url\(([^]+)\)/g, '$1')
       if (!url.startsWith('https://')) {
         const source = data.url
-        console.log('source', source.substr(0, source.lastIndexOf('/')), url)
         url = new URL(url, source).href
       }
-      console.log('URL', url)
       return new Promise((resolve, reject) => {
         fetch(url)
           .then((res: Response) => res.blob())


### PR DESCRIPTION
I was using this for creating screenshots as part of a feedback plugin on a site and needed to be able to properly render google fonts that were being loaded directly from google so I added this in. 

First time using TypeScript so wouldn't be suprised if I've done some ugly things. Feel free to point them out. Happy to keep this as my own fork if it's something you don't want in your version.
