### PR TITLE
Fix bad build for commonjs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "noUnusedLocals": true,
     "strictNullChecks": true,
     "esModuleInterop": true,
-    "module": "commonjs",
+    "module": "ES2015",
     "moduleResolution": "node",
     "target": "es5",
     "outDir": "./lib",


### PR DESCRIPTION
When you try get the package with unpkg:
  
`<script src="https://unpkg.com/html-to-image"></script>
`
You get an error:

`Object.defineProperty(exports, "__esModule", { value: true });
`
Because de Browser does not support exports.