### PR TITLE
added the pixel ratio to the options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ export type Options = {
    * areas for failed images.
    */
   imagePlaceholder?: string
+  /**
+   * Defalut vlaue is the actual pixel ratio of the device.
+   * Set 1 to use as initial-scale 1 for the image
+   */
+  pixelRatio?: number;
 }
 
 function getImageSize(domNode: HTMLElement, options: Options = {}) {
@@ -84,7 +89,7 @@ export async function toCanvas(
     .then((image) => {
       const canvas = document.createElement('canvas')
       const context = canvas.getContext('2d')!
-      const ratio = getPixelRatio()
+      const ratio = options.pixelRatio || getPixelRatio()
       const { width, height } = getImageSize(domNode, options)
 
       canvas.width = width * ratio


### PR DESCRIPTION
This is a fix for the newly opened issue. https://github.com/bubkoo/html-to-image/issues/59
 
What I did is, I introduced a variable for pixel ratio and set that pixel ratio or the default pixel ratio of the device. So now developer can set their own pixel ratio or if they did not set that variable in options then it gets the default ratio from the device. 