### PR TITLE
Avoid downloading same resources while rendering

### DIFF
--- a/src/applyStyleWithOptions.ts
+++ b/src/applyStyleWithOptions.ts
@@ -20,7 +20,8 @@ export function applyStyleWithOptions(
 
   const manual = options.style
   if (manual != null) {
-    Object.keys(manual).forEach((key: any) => {
+    Object.keys(manual).forEach((key) => {
+      // @ts-expect-error
       style[key] = manual[key]
     })
   }

--- a/src/getBlobFromURL.ts
+++ b/src/getBlobFromURL.ts
@@ -10,18 +10,25 @@ import { getDataURLContent } from './util'
 
 const TIMEOUT = 30000
 const cache: {
-  url: string
-  promise: Promise<string | null>
-}[] = []
+  [url: string]: Promise<string | null>
+} = {}
+
+function isFont(filename: string) {
+  return /ttf|otf|eot|woff2?/i.test(filename)
+}
 
 export function getBlobFromURL(
   url: string,
   options: Options,
 ): Promise<string | null> {
-  const root = url.split('?')[0]
-  const found = cache.find((item) => item.url === root)
-  if (found) {
-    return found.promise
+  let href = url.replace(/\?.*/, '')
+
+  if (isFont(href)) {
+    href = href.replace(/.*\//, '')
+  }
+
+  if (cache[href]) {
+    return cache[href]
   }
 
   // cache bypass so we dont have CORS issues with cached images
@@ -108,6 +115,7 @@ export function getBlobFromURL(
       })
 
   const promise = deferred.catch(failed) as Promise<string | null>
-  cache.push({ promise, url: root })
+  cache[href] = promise
+
   return promise
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export type Options = {
   /**
    * An object whose properties to be copied to node's style before rendering.
    */
-  style?: CSSStyleDeclaration
+  style?: Partial<CSSStyleDeclaration>
   /**
    * A function taking DOM node as argument. Should return `true` if passed
    * node should be included in the output. Excluding node means excluding

--- a/test/spec/index.spec.ts
+++ b/test/spec/index.spec.ts
@@ -319,7 +319,7 @@ describe('html to image', () => {
       Helper.bootstrap('style/node.html', 'style/style.css', 'style/image')
         .then((node) => {
           return htmlToImage.toPng(node, {
-            style: { 'background-color': 'red', transform: 'scale(0.5)' },
+            style: { backgroundColor: 'red', transform: 'scale(0.5)' },
           })
         })
         .then(Helper.check)
@@ -335,7 +335,7 @@ describe('html to image', () => {
             height: 200,
             style: {
               transform: 'scale(2)',
-              'transform-origin': 'top left',
+              transformOrigin: 'top left',
             },
           })
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

It reduces resource downloads such ass CSS and font files.

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
These changes basically fixes #34 and especially this https://github.com/bubkoo/html-to-image/issues/34#issuecomment-726795254
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [x] Test Case (changes that add missing tests or correct existing tests)
- [x] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
