### PR TITLE
fix: 🐛 use content-type to get image src type if extension is not provided in url

### DIFF
--- a/src/embedImages.ts
+++ b/src/embedImages.ts
@@ -49,7 +49,9 @@ function embedImageNode(
 
   return Promise.resolve(clonedNode.src)
     .then((url) => getBlobFromURL(url, options))
-    .then((data) => toDataURL(data!, getMimeType(clonedNode.src)))
+    .then((data) =>
+      toDataURL(data!.blob, getMimeType(clonedNode.src) || data!.contentType),
+    )
     .then(
       (dataURL) =>
         new Promise((resolve, reject) => {

--- a/src/embedResources.ts
+++ b/src/embedResources.ts
@@ -48,8 +48,19 @@ export function embed(
   const resolvedURL = baseURL ? resolveUrl(resourceURL, baseURL) : resourceURL
 
   return Promise.resolve(resolvedURL)
-    .then((url) => (get ? get(url) : getBlobFromURL(url, options)))
-    .then((data) => toDataURL(data!, getMimeType(resourceURL)))
+    .then<string | { blob: string; contentType: string } | null>((url) =>
+      get ? get(url) : getBlobFromURL(url, options),
+    )
+    .then((data) => {
+      if (typeof data === 'string') {
+        return toDataURL(data!, getMimeType(resourceURL))
+      }
+
+      return toDataURL(
+        data!.blob,
+        getMimeType(resourceURL) || data!.contentType,
+      )
+    })
     .then((dataURL) =>
       cssString.replace(urlToRegex(resourceURL), `$1${dataURL}$3`),
     )


### PR DESCRIPTION
### Description
- Modify getBlobFromURL to return the blob and the contentType
- Modify embedImages and embedResources to use the contentType provided by getBlobFromUrl to get the mime type of the file if source's extension is not provided.

### Motivation and Context
There are cases when the URL provided the img element does not contain the extension. This cause the conversion of the blob to the dataUrl failed, because the mime type returned from `getMimeType(node.src)` will be an empty string. In this scenario, the type can be retrieved from the Content-Type header response after fetching the resource.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
