### PR TITLE
fix: 🐛 parse @import rules in fetched CSS

### DIFF
--- a/src/embedWebFonts.ts
+++ b/src/embedWebFonts.ts
@@ -147,7 +147,8 @@ function parseCSS(source: string) {
   const combinedCSSRegex =
     '((\\s*?(?:\\/\\*[\\s\\S]*?\\*\\/)?\\s*?@media[\\s\\S]' +
     '*?){([\\s\\S]*?)}\\s*?})|(([\\s\\S]*?){([\\s\\S]*?)})' // to match css & media queries together
-  const cssCommentsRegex = new RegExp('(\\/\\*[\\s\\S]*?\\*\\/)', 'gi')
+  const cssCommentsRegex = /(\/\*[\s\S]*?\*\/)/gi
+  const importRegex = /@import[\s\S]*?url\([^)]*\)[\s\S]*?;/gi
 
   // strip out comments
   cssText = cssText.replace(cssCommentsRegex, '')
@@ -166,9 +167,17 @@ function parseCSS(source: string) {
   // unified regex
   const unified = new RegExp(combinedCSSRegex, 'gi')
   while (true) {
-    arr = unified.exec(cssText)
+    arr = importRegex.exec(cssText)
+
     if (arr === null) {
-      break
+      arr = unified.exec(cssText)
+      if (arr === null) {
+        break
+      } else {
+        importRegex.lastIndex = unified.lastIndex
+      }
+    } else {
+      unified.lastIndex = importRegex.lastIndex
     }
     css.push(arr[0])
   }


### PR DESCRIPTION
### Description

This ensures `@import` rules are parsed as separate rules from block-style rules.

### Motivation and Context

It fixes the problem with Adobe Fonts/Typekit outlined in #96. Fonts from that source have an `@import` rule that hits some analytics URL which returns a stylesheet with an empty comment. `html-to-image` already transforms the URL into a data URI but the regex for parsing the CSS is too greedy and captures both the `@import` rule and any following block-style rule as one rule.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [x] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

The fix includes 1 refactor of a regular expression into literal syntax. The other regular expressions could probably be refactored this way too but I didn't want to mess around with them too much as they are constructed in a different place from where they are written. The benefits are fairly obvious, but to summarise:

 * No need for double-escaping
 * Better syntax highlighting in editors
 * Compiled at parse time and optimisable by the browser

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Unfortunately there do not seem to be existing tests covering this code (or I missed them) and I haven't had the chance to work out the image comparison testing yet. If anyone has an idea of the best way to test this then I'd be happy to put the extra leg work in.