### PR TITLE
feat: ✨ option to specify preferred font format

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,23 @@ Defaults to an empty string and will render empty areas for failed images.
 
 ### pixelRatio
 
-The pixel ratio of the captured image. Defalut use the actual pixel ratio of the device. Set `1` to use as initial-scale `1` for the image.
+The pixel ratio of the captured image. Defalut use the actual pixel ratio of the device. Set `1` to
+use as initial-scale `1` for the image.
+
+### preferredFontFormat
+
+The format required for font embedding. This is a useful optimisation when a webfont provider
+specifies several different formats for fonts in the CSS, for example:
+
+```css
+@font-face {
+  name: 'proxima-nova';
+  src: url("...") format("woff2"), url("...") format("woff"), url("...") format("opentype");
+}
+```
+
+Instead of embedding each format, all formats other than the one specified will be discarded. If
+this option is not specified then all formats will be downloaded and embedded.
 
 ## Browsers
 

--- a/src/embedWebFonts.ts
+++ b/src/embedWebFonts.ts
@@ -18,7 +18,7 @@ export async function parseWebFontRules(
     }
     resolve(toArray(clonedNode.ownerDocument!.styleSheets))
   })
-    .then(getCssRules)
+    .then((styleSheets: CSSStyleSheet[]) => getCssRules(styleSheets))
     .then(getWebFontRules)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,17 @@ export type Options = {
    * Option to skip the fonts download and embed.
    */
   skipFonts?: boolean
+  /**
+   * The preferred font format. If specified all other font formats are ignored.
+   */
+  preferredFontFormat?:
+    | 'woff'
+    | 'woff2'
+    | 'truetype'
+    | 'opentype'
+    | 'embedded-opentype'
+    | 'svg'
+    | string
 }
 
 function getImageSize(domNode: HTMLElement, options: Options = {}) {

--- a/test/spec/helper.ts
+++ b/test/spec/helper.ts
@@ -138,6 +138,12 @@ export namespace Helper {
     })
   }
 
+  export function getSvgDocument(dataUrl: string): Promise<XMLDocument> {
+    return fetch(dataUrl)
+      .then((response) => response.text())
+      .then((str) => new window.DOMParser().parseFromString(str, 'text/xml'))
+  }
+
   function drawImg(
     image: CanvasImageSource,
     node = Helper.getCaptureNode(),

--- a/test/spec/index.spec.ts
+++ b/test/spec/index.spec.ts
@@ -380,6 +380,24 @@ describe('html to image', () => {
         .then(done)
         .catch(done)
     })
+
+    it('should embed only the preferred font', (done) => {
+      Helper.bootstrap(
+        'fonts/web-fonts/empty.html',
+        'fonts/web-fonts/remote.css',
+      )
+        .then((node) =>
+          htmlToImage.toSvg(node, { preferredFontFormat: 'woff2' }),
+        )
+        .then(Helper.getSvgDocument)
+        .then((doc) => {
+          const [style] = Array.from(doc.getElementsByTagName('style'))
+
+          expect(style.textContent).toMatch(/url\([^)]+\) format\("woff2"\)/)
+          expect(style.textContent).not.toMatch(/url\([^)]+\) format\("woff"\)/)
+        })
+        .then(done)
+    })
   })
 
   describe('special cases', () => {


### PR DESCRIPTION
### Description

This new feature adds a string option called `preferredFontFormat`. When the option is specified, all font formats that do not match the string given are not embedded in the resulting CSS. 

### Motivation and Context

Unlike Google Fonts, Adobe Fonts/TypeKit does not perform any browser detection before serving up its CSS files. This means it has to define each font format in a single `src` property, like this:

```css
src: url("...") format("woff2"), url("...") format ("woff"), url("...") format("opentype");
```

This results in each variant (normal, different weights, italic, etc) being downloaded 3 times—one per format in this case. It's wasteful and, if the library functions are called multiple times, it can add up to a lot of time wasted. In our case, calling `.toCanvas()` 13 times on separate HTML elements took ~90 seconds (including our code that forces lazy loaded images to be loaded first). With this option in place and us specifying `woff2`—supported by all our target browsers—as our preferred format, we were able to reduce this time by two thirds to around 30 seconds.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
