### PR TITLE
feat: ✨ option to specify font embed css

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ specifies several different formats for fonts in the CSS, for example:
 Instead of embedding each format, all formats other than the one specified will be discarded. If
 this option is not specified then all formats will be downloaded and embedded.
 
+### fontEmbedCss
+
+When supplied, the library will skip the process of parsing and embedding webfont URLs in CSS, 
+instead using this value. This is useful when combined with `.getFontEmbedCss()` to only perform the
+embedding process a single time across multiple calls to library functions.
+
+```javascript
+const fontEmbedCss = await htmlToImage.getFontEmbedCss(element1);
+html2Image.toSVG(element1, { fontEmbedCss });
+html2Image.toSVG(element2, { fontEmbedCss });
+```
+
 ## Browsers
 
 Only standard lib is currently used, but make sure your browser supports:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { cloneNode } from './cloneNode'
 import { embedImages } from './embedImages'
-import { embedWebFonts } from './embedWebFonts'
+import { embedWebFonts, getWebFontCss } from './embedWebFonts'
 import { createSvgDataURL } from './createSvgDataURL'
 import { applyStyleWithOptions } from './applyStyleWithOptions'
 import {
@@ -71,6 +71,11 @@ export type Options = {
     | 'embedded-opentype'
     | 'svg'
     | string
+  /**
+   * A CSS string to specify for font embeds. If specified only this CSS will be present in the resulting image.
+   * Use with `getFontEmbedCss()` to create embed CSS for use across multiple calls to library functions.
+   */
+  fontEmbedCss?: string
 }
 
 function getImageSize(domNode: HTMLElement, options: Options = {}) {
@@ -155,4 +160,11 @@ export async function toBlob(
   options: Options = {},
 ): Promise<Blob | null> {
   return toCanvas(domNode, options).then(canvasToBlob)
+}
+
+export async function getWebFontEmbedCss(
+  domNode: HTMLElement,
+  options: Options = {},
+): Promise<string> {
+  return getWebFontCss(domNode, options)
 }

--- a/test/spec/index.spec.ts
+++ b/test/spec/index.spec.ts
@@ -381,6 +381,28 @@ describe('html to image', () => {
         .catch(done)
     })
 
+    it('should only use fontEmbedCss if it is supplied', (done) => {
+      const testCss = `
+        @font-face {
+          name: "Arial";
+          src: url("data:AAA") format("woff2");
+        }
+      `
+      Helper.bootstrap(
+        'fonts/web-fonts/empty.html',
+        'fonts/web-fonts/remote.css',
+      )
+        .then((node) => htmlToImage.toSvg(node, { fontEmbedCss: testCss }))
+        .then(Helper.getSvgDocument)
+        .then((doc) => {
+          const styles = Array.from(doc.getElementsByTagName('style'))
+
+          expect(styles).toHaveSize(1)
+          expect(styles[0].textContent).toEqual(testCss)
+        })
+        .then(done)
+    })
+
     it('should embed only the preferred font', (done) => {
       Helper.bootstrap(
         'fonts/web-fonts/empty.html',


### PR DESCRIPTION
### Description

This builds on the [previous optimisation](https://github.com/bubkoo/html-to-image/pull/106) that lets you specify `preferredFontFormat` with another new option: `fontEmbedCss`. When this option is supplied, the majority of the font embedding process is skipped and only the supplied CSS is used.

To compliment the option a new exported method, `getFontEmbedCss(node, options)`, will run the majority of the process.

### Motivation and Context

When calling the library multiple times for different elements, the embed code is run each time. This is where most of the execution time is spent when snapshotting elements on pages with webfonts. This change allows you to do the heavy lifting up front a single time so that the snapshotting process is much faster. In our testing, this further reduced time spent snapshotting 13 elements on the page from over 30 seconds to 12-13 seconds on average.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
