### PR TITLE
feat(tocanvas): ✨ adding custom width/height for exported canvas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,14 @@ export type Options = {
    */
   backgroundColor?: string
   /**
+   * Width in pixels to be applied to canvas on export.
+   */
+  canvasWidth?: number
+  /**
+   * Height in pixels to be applied to canvas on export.
+   */
+  canvasHeight?: number
+  /**
    * An object whose properties to be copied to node's style before rendering.
    */
   style?: Partial<CSSStyleDeclaration>
@@ -76,6 +84,7 @@ export type Options = {
 function getImageSize(domNode: HTMLElement, options: Options = {}) {
   const width = options.width || getNodeWidth(domNode)
   const height = options.height || getNodeHeight(domNode)
+
   return { width, height }
 }
 
@@ -107,10 +116,15 @@ export async function toCanvas(
       const ratio = options.pixelRatio || getPixelRatio()
       const { width, height } = getImageSize(domNode, options)
 
-      canvas.width = width * ratio
-      canvas.height = height * ratio
-      canvas.style.width = `${width}`
-      canvas.style.height = `${height}`
+      const canvasWidth = options.canvasWidth || width
+      const canvasHeight = options.canvasHeight || height
+
+      canvas.width = canvasWidth * ratio
+      canvas.height = canvasHeight * ratio
+      canvas.style.width = `${canvasWidth}`
+      canvas.style.height = `${canvasHeight}`
+
+      console.log(canvas.width)
 
       if (options.backgroundColor) {
         context.fillStyle = options.backgroundColor

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,8 +124,6 @@ export async function toCanvas(
       canvas.style.width = `${canvasWidth}`
       canvas.style.height = `${canvasHeight}`
 
-      console.log(canvas.width)
-
       if (options.backgroundColor) {
         context.fillStyle = options.backgroundColor
         context.fillRect(0, 0, canvas.width, canvas.height)


### PR DESCRIPTION
Adding options canvasWidth and canvasHeight to control
size of the exported image, without having to resize the source
node element.

<!--- Provide a general summary of your changes in the Title above -->

### Description

Adding canvasWidth and canvasHeight to options.
If specified, use canvasWidth and canvasHeight when setting canvas.width and canvas.height.
If not specified, default to width/height from getImagesize()

### Motivation and Context

Need to control the resolution of the exported canvas.
Setting options.width or options.height doesn't scale the underlying text and elements within the domNode. 
With this change, the exported canvas width/height can be controlled and scaled.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
