### PR TITLE
Replace scrollWidth/Height with clientWidth/Height

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -99,13 +99,13 @@ function px(node: HTMLElement, styleProperty: string) {
 export function getNodeWidth(node: HTMLElement) {
   const leftBorder = px(node, 'border-left-width')
   const rightBorder = px(node, 'border-right-width')
-  return node.scrollWidth + leftBorder + rightBorder
+  return node.clientWidth + leftBorder + rightBorder
 }
 
 export function getNodeHeight(node: HTMLElement) {
   const topBorder = px(node, 'border-top-width')
   const bottomBorder = px(node, 'border-bottom-width')
-  return node.scrollHeight + topBorder + bottomBorder
+  return node.clientHeight + topBorder + bottomBorder
 }
 
 export function getPixelRatio() {


### PR DESCRIPTION
Overflowing child elements cause unnecessary empty padding around the rendered image because scrollWidth/Height calculate the node's width/height including all the overflowing elements

### Description

Change scrollWidth/scrollHeight to clientWidth/clientHeight

### Motivation and Context

It fixed the issue mentioned here (by me) : [Issue 126](https://github.com/bubkoo/html-to-image/issues/126)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
