### PR TITLE
feat: ✨ Add viewBox attribute to SVG

### DIFF
--- a/src/createSvgDataURL.ts
+++ b/src/createSvgDataURL.ts
@@ -11,6 +11,7 @@ export function createSvgDataURL(
 
   svg.setAttributeNS('', 'width', `${width}`)
   svg.setAttributeNS('', 'height', `${height}`)
+  svg.setAttributeNS('', 'viewBox', `0 0 ${width} ${height}`)
 
   foreignObject.setAttributeNS('', 'width', '100%')
   foreignObject.setAttributeNS('', 'height', '100%')

--- a/test/spec/index.spec.ts
+++ b/test/spec/index.spec.ts
@@ -300,6 +300,20 @@ describe('html to image', () => {
         .then(done)
         .catch(done)
     })
+
+    it('should include a viewBox attribute', (done) => {
+      Helper.bootstrap('small/node.html', 'small/style.css', 'small/image')
+        .then(htmlToImage.toSvg)
+        .then(Helper.getSvgDocument)
+        .then((doc) => {
+          const width = doc.documentElement.getAttribute('width')
+          const height = doc.documentElement.getAttribute('height')
+          const viewBox = doc.documentElement.getAttribute('viewBox')
+          expect(viewBox).toEqual(`0 0 ${width} ${height}`)
+        })
+        .then(done)
+        .catch(done)
+    })
   })
 
   describe('work with options', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Adds a [viewBox](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox) attribute to rendered SVGs. 

This change just sets the `viewBox` to match the `width` and `height` attributes that are already being set on the SVG, so the image isn't visually altered by this change. Example:

```
<svg xmlns="http://www.w3.org/2000/svg" width="100" height="9" viewBox="0 0 100 9">
```

### Motivation and Context

Having a `viewBox` set helps with allowing a browser to auto-scale the SVG when it's displayed inside a parent container (for example, a `<div>` wrapper of a different size than the image).

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

The `should render content from shadow node of custom element` test is failing in `master`, so this change doesn't address that.