### PR TITLE
fix: 🐛 ternary to convert slot assignedNodes to array

### DIFF
--- a/src/cloneNode.ts
+++ b/src/cloneNode.ts
@@ -33,7 +33,10 @@ async function cloneChildren<T extends HTMLElement>(
   clonedNode: T,
   options: Options,
 ): Promise<T> {
-  const children = toArray<T>((nativeNode.shadowRoot ?? nativeNode).childNodes)
+  const children =
+    isSlotElement(nativeNode) && nativeNode.assignedNodes
+      ? toArray<T>(nativeNode.assignedNodes())
+      : toArray<T>((nativeNode.shadowRoot ?? nativeNode).childNodes)
 
   if (children.length === 0) {
     return Promise.resolve(clonedNode)
@@ -114,3 +117,6 @@ export async function cloneNode<T extends HTMLElement>(
     .then((clonedNode) => cloneChildren(nativeNode, clonedNode, options))
     .then((clonedNode) => decorate(nativeNode, clonedNode))
 }
+
+const isSlotElement = (node: Element): node is HTMLSlotElement =>
+  node.tagName === 'SLOT'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Need to handle `slot.assignedNodes` in `cloneNode.ts`

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is required because slot nodes currently are skipped.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/bubkoo/html-to-image/issues/164
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

`should render content from shadow node of custom element` is failing even though the base64 strings are identical... I am not familiar with this style of test-bed and your helper impl's so it was difficult for me to identify the issue... I am also on `WSL` so it is very plausible that this is only an issue on my local dev environment.
