### PR TITLE
Add type option to save canvas.toBlob as web or jpeg...

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ You may experience loss of parts of the image if set to `true` and you are expor
 
 Defaults to `false`  
 
+### type
+
+A string indicating the image format. The default type is image/png; that type is also used if the given type isn't supported.
+When supplied, the toCanvas function will return a blob matching the given image type and quality. 
+
+Defaults to `image/png`  
 
 ## Browsers
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -75,4 +75,8 @@ export interface Options {
    * A boolean to turn off auto scaling for truly massive images..
    */
   skipAutoScale?: boolean
+  /**
+   * A string indicating the image format. The default type is image/png; that type is also used if the given type isn't supported.
+   */
+  type?: string
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { Options } from './options'
+
 const WOFF = 'application/font-woff'
 const JPEG = 'image/jpeg'
 const mimes: { [key: string]: string } = {
@@ -138,13 +140,29 @@ export function getPixelRatio() {
   return ratio || window.devicePixelRatio || 1
 }
 
-export function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
+export function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  options: Options = {},
+): Promise<Blob | null> {
   if (canvas.toBlob) {
-    return new Promise((resolve) => canvas.toBlob(resolve))
+    return new Promise((resolve) =>
+      canvas.toBlob(
+        resolve,
+        options.type ? options.type : 'image/png',
+        options.quality ? options.quality : 1,
+      ),
+    )
   }
 
   return new Promise((resolve) => {
-    const binaryString = window.atob(canvas.toDataURL().split(',')[1])
+    const binaryString = window.atob(
+      canvas
+        .toDataURL(
+          options.type ? options.type : undefined,
+          options.quality ? options.quality : undefined,
+        )
+        .split(',')[1],
+    )
     const len = binaryString.length
     const binaryArray = new Uint8Array(len)
 
@@ -152,7 +170,11 @@ export function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
       binaryArray[i] = binaryString.charCodeAt(i)
     }
 
-    resolve(new Blob([binaryArray], { type: 'image/png' }))
+    resolve(
+      new Blob([binaryArray], {
+        type: options.type ? options.type : 'image/png',
+      }),
+    )
   })
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Added the string type option to options.ts and updated util.ts to use it, falling back to image/png.  Also updated util.ts to use the options quality value.

### Motivation and Context

It solves the problem of having to convert the canvas output later in a process from image/png.  Simply implemented what the spec already provides (i.e. type, quality and support for image/webp and image/jpeg per:

https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
