### PR TITLE
feat: add 'fetchRequestInit' option

### DIFF
--- a/src/getBlobFromURL.ts
+++ b/src/getBlobFromURL.ts
@@ -63,7 +63,7 @@ export function getBlobFromURL(
   }
 
   const deferred = window
-    .fetch(url)
+    .fetch(url, options.fetchRequestInit)
     .then((res) =>
       // eslint-disable-next-line promise/no-nesting
       res.blob().then((blob) => ({

--- a/src/options.ts
+++ b/src/options.ts
@@ -79,4 +79,11 @@ export interface Options {
    * A string indicating the image format. The default type is image/png; that type is also used if the given type isn't supported.
    */
   type?: string
+
+  /**
+   *
+   *the second parameter of  window.fetch (Promise<Response> fetch(input[, init]))
+   *
+   */
+  fetchRequestInit?: RequestInit
 }


### PR DESCRIPTION
### `window.fetch()` allow to config

the `fetch` used in html-to-image should be config. because when image are cross origin , we should use fetch like this:
```
window.fetch(url, { credentials: 'include' } )
```



