### PR TITLE
Revert bad contribution

### DIFF
--- a/src/embedWebFonts.ts
+++ b/src/embedWebFonts.ts
@@ -125,7 +125,7 @@ async function getCSSRules(
   styleSheets.forEach((sheet) => {
     if ('cssRules' in sheet) {
       try {
-        toArray<CSSRule>(sheet.hasOwnProperty('cssRules')).forEach(
+        toArray<CSSRule>(sheet.cssRules).forEach(
           (item: CSSRule, index: number) => {
             if (item.type === CSSRule.IMPORT_RULE) {
               let importIndex = index + 1
@@ -141,7 +141,7 @@ async function getCSSRules(
                         rule,
                         rule.startsWith('@import')
                           ? (importIndex += 1)
-                          : sheet.hasOwnProperty('cssRules').length,
+                          : sheet.cssRules.length,
                       )
                     } catch (error) {
                       console.error('Error inserting rule from remote css', {
@@ -170,7 +170,7 @@ async function getCSSRules(
               )
               .then((cssText) =>
                 parseCSS(cssText).forEach((rule) => {
-                  inline.insertRule(rule, sheet.hasOwnProperty('cssRules').length)
+                  inline.insertRule(rule, sheet.cssRules.length)
                 }),
               )
               .catch((err) => {
@@ -188,7 +188,7 @@ async function getCSSRules(
     styleSheets.forEach((sheet) => {
       if ('cssRules' in sheet) {
         try {
-          toArray<CSSStyleRule>(sheet.hasOwnProperty('cssRules')).forEach(
+          toArray<CSSStyleRule>(sheet.cssRules).forEach(
             (item: CSSStyleRule) => {
               ret.push(item)
             },

--- a/src/embedWebFonts.ts
+++ b/src/embedWebFonts.ts
@@ -177,8 +177,9 @@ async function getCSSRules(
                 console.error('Error loading remote stylesheet', err.toString())
               }),
           )
+        } else {
+          console.error('Error inlining remote css file', e.toString())
         }
-        console.error('Error inlining remote css file', e.toString())
       }
     }
   })


### PR DESCRIPTION
### Description

Reverts #218 since it breaks the build and doesn't do anything useful since `SecurityError`s are already correctly handled.

However, I'm guessing the user took issue with the error message being logged. Thus I've ensured the "Error inlining remote css file" error is only logged if deferred loading is not an option.

### Motivation and Context

Project didn't build.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
  _N/A - This fixes the build. Tests still fail, but are unrelated to this PR. However, I'm about to submit a second PR to fix the tests._
- [ ] All new and existing tests passed.
  _Nope. Existing tests fail. At least locally. As above, issue is not introduced in this PR._
