### PR TITLE
fix: 🐛 allow capturing of images in child windows

### DIFF
--- a/src/cloneNode.ts
+++ b/src/cloneNode.ts
@@ -25,11 +25,14 @@ async function cloneSingleNode<T extends HTMLElement>(
   node: T,
   options: Options,
 ): Promise<HTMLElement> {
-  if (node instanceof HTMLCanvasElement) {
+  if (node instanceof node.ownerDocument.defaultView!.HTMLCanvasElement) {
     return cloneCanvasElement(node)
   }
 
-  if (node instanceof HTMLVideoElement && node.poster) {
+  if (
+    node instanceof node.ownerDocument.defaultView!.HTMLVideoElement &&
+    node.poster
+  ) {
     return cloneVideoElement(node, options)
   }
 
@@ -49,7 +52,10 @@ async function cloneChildren<T extends HTMLElement>(
       ? toArray<T>(nativeNode.assignedNodes())
       : toArray<T>((nativeNode.shadowRoot ?? nativeNode).childNodes)
 
-  if (children.length === 0 || nativeNode instanceof HTMLVideoElement) {
+  if (
+    children.length === 0 ||
+    nativeNode instanceof nativeNode.ownerDocument.defaultView!.HTMLVideoElement
+  ) {
     return Promise.resolve(clonedNode)
   }
 
@@ -71,7 +77,8 @@ async function cloneChildren<T extends HTMLElement>(
 }
 
 function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
-  const source = window.getComputedStyle(nativeNode)
+  const window = nativeNode.ownerDocument.defaultView
+  const source = window!.getComputedStyle(nativeNode)
   const target = clonedNode.style
 
   if (!target) {
@@ -92,11 +99,16 @@ function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
 }
 
 function cloneInputValue<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
-  if (nativeNode instanceof HTMLTextAreaElement) {
+  if (
+    nativeNode instanceof
+    nativeNode.ownerDocument.defaultView!.HTMLTextAreaElement
+  ) {
     clonedNode.innerHTML = nativeNode.value
   }
 
-  if (nativeNode instanceof HTMLInputElement) {
+  if (
+    nativeNode instanceof nativeNode.ownerDocument.defaultView!.HTMLInputElement
+  ) {
     clonedNode.setAttribute('value', nativeNode.value)
   }
 }
@@ -105,7 +117,7 @@ async function decorate<T extends HTMLElement>(
   nativeNode: T,
   clonedNode: T,
 ): Promise<T> {
-  if (!(clonedNode instanceof Element)) {
+  if (!(clonedNode instanceof clonedNode.ownerDocument.defaultView!.Element)) {
     return Promise.resolve(clonedNode)
   }
 

--- a/src/clonePseudoElements.ts
+++ b/src/clonePseudoElements.ts
@@ -36,7 +36,8 @@ function clonePseudoElement<T extends HTMLElement>(
   clonedNode: T,
   pseudo: Pseudo,
 ) {
-  const style = window.getComputedStyle(nativeNode, pseudo)
+  const window = nativeNode.ownerDocument.defaultView
+  const style = window!.getComputedStyle(nativeNode, pseudo)
   const content = style.getPropertyValue('content')
   if (content === '' || content === 'none') {
     return

--- a/src/embedImages.ts
+++ b/src/embedImages.ts
@@ -30,9 +30,14 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
   options: Options,
 ): Promise<T> {
   if (
-    !(clonedNode instanceof HTMLImageElement && !isDataUrl(clonedNode.src)) &&
     !(
-      clonedNode instanceof SVGImageElement &&
+      clonedNode instanceof
+        clonedNode.ownerDocument.defaultView!.HTMLImageElement &&
+      !isDataUrl(clonedNode.src)
+    ) &&
+    !(
+      clonedNode instanceof
+        clonedNode.ownerDocument.defaultView!.SVGImageElement &&
       !isDataUrl(clonedNode.href.baseVal)
     )
   ) {
@@ -40,7 +45,7 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
   }
 
   const src =
-    clonedNode instanceof HTMLImageElement
+    clonedNode instanceof clonedNode.ownerDocument.defaultView!.HTMLImageElement
       ? clonedNode.src
       : clonedNode.href.baseVal
 
@@ -54,7 +59,10 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
         new Promise((resolve, reject) => {
           clonedNode.onload = resolve
           clonedNode.onerror = reject
-          if (clonedNode instanceof HTMLImageElement) {
+          if (
+            clonedNode instanceof
+            clonedNode.ownerDocument.defaultView!.HTMLImageElement
+          ) {
             clonedNode.srcset = ''
             clonedNode.src = dataURL
           } else {
@@ -82,7 +90,7 @@ export async function embedImages<T extends HTMLElement>(
   clonedNode: T,
   options: Options,
 ): Promise<T> {
-  if (!(clonedNode instanceof Element)) {
+  if (!(clonedNode instanceof clonedNode.ownerDocument.defaultView!.Element)) {
     return Promise.resolve(clonedNode)
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -101,7 +101,8 @@ export function toArray<T>(arrayLike: any): T[] {
 }
 
 function px(node: HTMLElement, styleProperty: string) {
-  const val = window.getComputedStyle(node).getPropertyValue(styleProperty)
+  const window = node.ownerDocument.defaultView
+  const val = window!.getComputedStyle(node).getPropertyValue(styleProperty)
   return parseFloat(val.replace('px', ''))
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description

Replace `window` with `Element.ownerDocument.defaultView` where necessary to allow images to be captured of elements in a child window.

### Motivation and Context

When attempting to capture images of a popped-out child window styles aren't copied. For example, in a charting app where the chart can be popped out into a child window, the expected image is this:
![image](https://user-images.githubusercontent.com/35851172/149419413-e7b0a979-33be-4fd8-aef7-5e6f9b1a122b.png)

But, using html-to-image to get the image of the popped out chart produces this image:
![image](https://user-images.githubusercontent.com/35851172/149419451-e76158fc-43a2-4290-a04c-df9c4f153e08.png)

Note that the legend styles are missing, as well as the legend entry. Replacing `window` with `Element.ownerDocument.defaultView` ensures the correct context is being used for the element and eliminates the issue above.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
