### PR TITLE
feat: ✨ user can modify cloned Node CSS Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,41 @@ htmlToImage.toPng(node, {filter:filter})
 
 Not called on the root node.
 
+### cssStyleInterceptor
+
+```ts
+<T extends HTMLElement>(domNode: T, styleName: string, originStyleValue: string) => string
+```
+
+A function taking DOM node and the DOM node's styleName as argument. Should return `new styleValue` if you need modify the style or `originStyleValue` if you needn't change the style.
+
+We have known html-to-image will compute the style of origin node assign to clonedNode, if you want to change clonedNode css style and **don't impact the origin node**, use it.
+
+```ts
+const filter = {
+      cssStyleInterceptor: (domNode: HTMLElement, styleName: string, originStyleValue: string) => {
+        const classes = domNode.classList
+        const processClasses = ['n-data-table']
+        // you want to make the node with `n-data-table` class don't show scroll-bar in the svg
+        if (processClasses.some(processClass => classes.contains(processClass))) {
+          if (styleName === 'max-height') {
+            return 'none'
+          }
+
+          if (styleName === 'height') {
+            return 'fit-content'
+          }
+
+          if (styleName.startsWith('overflow')) {
+            return 'hidden'
+          }
+        }
+
+        return originStyleValue
+    },
+}
+```
+
 ### backgroundColor
 
 A string value for the background color, any valid CSS color value.

--- a/src/options.ts
+++ b/src/options.ts
@@ -30,6 +30,15 @@ export interface Options {
    */
   filter?: (domNode: HTMLElement) => boolean
   /**
+   * A function taking DOM node and the DOM node's styleName as argument. Should return `new styleValue` if
+   * you need modify the style or `originStyleValue` if you needn't change the style
+   */
+  cssStyleInterceptor?: <T extends HTMLElement>(
+    domNode: T,
+    styleName: string,
+    originStyleValue: string,
+  ) => string
+  /**
    * A number between `0` and `1` indicating image quality (e.g. 0.92 => 92%)
    * of the JPEG image.
    */

--- a/src/util.ts
+++ b/src/util.ts
@@ -189,11 +189,12 @@ export function createImage(url: string): Promise<HTMLImageElement> {
   })
 }
 
+export const SVG_PREFIX = 'data:image/svg+xml;charset=utf-8,'
 export async function svgToDataURL(svg: SVGElement): Promise<string> {
   return Promise.resolve()
     .then(() => new XMLSerializer().serializeToString(svg))
     .then(encodeURIComponent)
-    .then((html) => `data:image/svg+xml;charset=utf-8,${html}`)
+    .then((html) => SVG_PREFIX + html)
 }
 
 export async function nodeToDataURL(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->
The user can control the style of the cloned node.
I need to convert a table to SVG, but this table has max-height. When converting to SVG, there will be a scrollbar. By adding the cssStyleInterceptor interceptor into options, users can manually clone nodes and remove max-height.

This PR solves a similar problem to [issue#215 Modify cloned nodes before cloneCSSStyle](https://github.com/bubkoo/html-to-image/issues/215)
### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
