### PR TITLE
fix: 🐛 text breaks on the last word

### DIFF
--- a/src/cloneNode.ts
+++ b/src/cloneNode.ts
@@ -82,11 +82,14 @@ function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
     target.cssText = source.cssText
   } else {
     toArray<string>(source).forEach((name) => {
-      target.setProperty(
-        name,
-        source.getPropertyValue(name),
-        source.getPropertyPriority(name),
-      )
+      let value = source.getPropertyValue(name)
+
+      if (name === 'font-size' && value.endsWith('px')) {
+        const reducedFont =
+          Math.floor(parseFloat(value.substring(0, value.length - 2))) - 0.1
+        value = `${reducedFont}px`
+      }
+      target.setProperty(name, value, source.getPropertyPriority(name))
     })
   }
 }


### PR DESCRIPTION
Reduced font-size for elements because text don't fit in the blocks.

### Description

Decimal font size in CSS and font-size in SVG are different.
#132

In SVG, when text is scaled up or down, browsers calculate the final size of the text (which is determined by the specified font size and the applied scale) and request a font of that computed size from the platform's font system. But if you request a font size of, say, 9 with a scale of 140%, the resulting font size of 12.6 doesn't explicitly exist in the font system, so the browser rounds the font size to 12 instead. This results in stair-step scaling of text.


### Motivation and Context

Issue #132
![image](https://user-images.githubusercontent.com/13537063/164033723-764c26fa-0bf5-471c-ba82-964582f292aa.png)

Reduce font-size in clone styles method

### Types of changes


- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
