### PR TITLE
fix: 🐛  selected option not preserved in image

### DIFF
--- a/src/cloneNode.ts
+++ b/src/cloneNode.ts
@@ -101,6 +101,19 @@ function cloneInputValue<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
   }
 }
 
+function cloneSelectValue<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
+  if (nativeNode instanceof HTMLSelectElement) {
+    const clonedSelect = clonedNode as any as HTMLSelectElement
+    const selectedOption = Array.from(clonedSelect.children).find(
+      (child) => nativeNode.value === child.getAttribute('value'),
+    )
+
+    if (selectedOption) {
+      selectedOption.setAttribute('selected', '')
+    }
+  }
+}
+
 async function decorate<T extends HTMLElement>(
   nativeNode: T,
   clonedNode: T,
@@ -113,6 +126,7 @@ async function decorate<T extends HTMLElement>(
     .then(() => cloneCSSStyle(nativeNode, clonedNode))
     .then(() => clonePseudoElements(nativeNode, clonedNode))
     .then(() => cloneInputValue(nativeNode, clonedNode))
+    .then(() => cloneSelectValue(nativeNode, clonedNode))
     .then(() => clonedNode)
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Set `selected` attribute on the option with a value that corresponds to the value of the select tag.

<!--- Describe your changes in detail -->
### Motivation and Context

Problem as described in issue https://github.com/bubkoo/html-to-image/issues/277
The value of select tags is not stored in the html and are thus lost in the `clonedNode`.

Setting the `selected` attribute on the option ensures that it is preserved in the final image.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
