### PR TITLE
fix: 🐛 cloneCSSStyle: copy transformOriginProp

### DIFF
--- a/src/cloneNode.ts
+++ b/src/cloneNode.ts
@@ -80,6 +80,7 @@ function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
 
   if (source.cssText) {
     target.cssText = source.cssText
+    target.transformOrigin = source.transformOrigin
   } else {
     toArray<string>(source).forEach((name) => {
       target.setProperty(


### PR DESCRIPTION
Safari `cssText` does not include transform-origin prop

<!--- Provide a general summary of your changes in the Title above -->

### Description

The only change was to copy transform-origin prop additionally with copying the cssText from source to target node

### Motivation and Context

Problem was described in issue https://github.com/bubkoo/html-to-image/issues/296

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.