### PR TITLE
fix(cloneCSSStyle): rounded values of d attribute fix

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -114,6 +114,9 @@ function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
           Math.floor(parseFloat(value.substring(0, value.length - 2))) - 0.1
         value = `${reducedFont}px`
       }
+      if (name === 'd' && clonedNode.getAttribute('d')) {
+        value = `path(${clonedNode.getAttribute('d')})`
+      }
       targetStyle.setProperty(
         name,
         value,


### PR DESCRIPTION
There is a difference between values in actual d attribute of path and value that returns from window.getComputedStyles() object For some generated svg shapes at particular place is crutial to have exact values in order them to be displayed at all.

Closes #357

<!--- Provide a general summary of your changes in the Title above -->

### Description
There is a problem appears for `path` elements with precise values in `d` attribute on cloneCSSStyle step.
`window.getComputedStyles() ` which is used to get styles to apply them on cloned element returns rounded values
which is wrong for some elements.
For e.g here I'm inspecting cloned element and the elements are actually present but because of rounded values after styles were copied they are invisible with height 0 and width 0:
<img width="779" alt="image" src="https://user-images.githubusercontent.com/31307316/210871718-7d450e9c-4b2c-4895-a620-a91185a2d759.png">

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
