### PR TITLE
fix: switch lazy loading images to eager

### DIFF
--- a/src/embed-images.ts
+++ b/src/embed-images.ts
@@ -48,6 +48,10 @@ async function embedImageNode<T extends HTMLElement | SVGImageElement>(
       image.decode = resolve as any
     }
 
+    if (image.loading === 'lazy') {
+      image.loading = 'eager'
+    }
+
     if (clonedNode instanceof HTMLImageElement) {
       clonedNode.srcset = ''
       clonedNode.src = dataURL


### PR DESCRIPTION
I noticed an issue with my images not loading. I traced it to neither `onload` or `onerror` firing during the `embedImageNode` step, which I was able to fix by changing the `loading` (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading) attribute to `eager` instead of `lazy` as my images are.

### Description

Add a condition during `embedImageNode` that changes lazy loading images to eager to ensure (ideally) that onload/onerror fires.

### Motivation and Context

This problem occurs at least for me when I have an `img` which has `loading` (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading) set to `lazy`. Changing this to `eager` stops the problem, so I've made this adjustment occur during cloning as we would not want to lazy loading images when we are trying to clone them and are waiting for them to finish decoding/loading.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
