### PR TITLE
Fixes issue fetching font css when cssRules are inaccessilbe

### DIFF
--- a/src/embed-webfonts.ts
+++ b/src/embed-webfonts.ts
@@ -151,7 +151,7 @@ async function getCSSRules(
               .then((metadata) => embedFonts(metadata, options))
               .then((cssText) =>
                 parseCSS(cssText).forEach((rule) => {
-                  inline.insertRule(rule, sheet.cssRules.length)
+                  inline.insertRule(rule, inline.cssRules.length)
                 }),
               )
               .catch((err: unknown) => {


### PR DESCRIPTION
Fixes the handling of font css when cssRules are inaccessible.

### Description

When cssRules are inaccessible in a style sheet, getCSSRules will throw an exception trying to read them, and then the catch handler will fetch the css. But, when it goes to insert the rule, it has a bug where it uses sheet.cssRules.length, which causes an exception again and the rules are lost.

This results in the error:

```
Error inlining remote css file SecurityError: Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules
```

This is referenced in a few issues such as issue #49.

### Motivation and Context

This fixes issues when fonts are referenced via external style sheets and the css cannot be read. The resulting image
will be missing the fonts that failed. This error is mentioned in a few issues such as https://github.com/bubkoo/html-to-image/issues/49.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
