### PR TITLE
Handle `href ` use attribute

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -133,11 +133,11 @@ function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
       ) {
         value = 'block'
       }
-      
+
       if (name === 'd' && clonedNode.getAttribute('d')) {
         value = `path(${clonedNode.getAttribute('d')})`
       }
-      
+
       targetStyle.setProperty(
         name,
         value,
@@ -193,7 +193,7 @@ async function ensureSVGSymbols<T extends HTMLElement>(
   const processedDefs: { [key: string]: HTMLElement } = {}
   for (let i = 0; i < uses.length; i++) {
     const use = uses[i]
-    const id = use.getAttribute('xlink:href')
+    const id = use.getAttribute('href') ?? use.getAttribute('xlink:href')
     if (id) {
       const exist = clone.querySelector(id)
       const definition = document.querySelector(id) as HTMLElement


### PR DESCRIPTION
Refs: #392 

### Description

This PR adds support for `href` attribute for the `use` svg elements.

### Motivation and Context

[xlink:href is deprecated](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href). Users should use `href` param for the same behaviour.

### Breaking Changes

Hopefully, none.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)
