### PR TITLE
fix: workaround for respecting scrollbar positions

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -133,11 +133,11 @@ function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
       ) {
         value = 'block'
       }
-      
+
       if (name === 'd' && clonedNode.getAttribute('d')) {
         value = `path(${clonedNode.getAttribute('d')})`
       }
-      
+
       targetStyle.setProperty(
         name,
         value,
@@ -170,12 +170,41 @@ function cloneSelectValue<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
   }
 }
 
+function cloneScrollbarPositions<T extends HTMLElement>(
+  nativeNode: T,
+  clonedNode: T,
+) {
+  if (nativeNode.scrollLeft !== 0 || nativeNode.scrollTop !== 0) {
+    for (let i = 0; i < clonedNode.children.length; i += 1) {
+      const child = clonedNode.childNodes[i] as any as HTMLSelectElement
+      if (!child.style) return
+      const u = new DOMMatrix(child.style.transform)
+      const a = u.a
+      const b = u.b
+      const c = u.c
+      const d = u.d
+      u.a = 1
+      u.b = 0
+      u.c = 0
+      u.d = 1
+      u.translateSelf(-nativeNode.scrollLeft, -nativeNode.scrollTop)
+      u.a = a
+      u.b = b
+      u.c = c
+      u.d = d
+      child.style.transform = u.toString()
+    }
+    clonedNode.style.overflow = 'hidden'
+  }
+}
+
 function decorate<T extends HTMLElement>(nativeNode: T, clonedNode: T): T {
   if (isInstanceOfElement(clonedNode, Element)) {
     cloneCSSStyle(nativeNode, clonedNode)
     clonePseudoElements(nativeNode, clonedNode)
     cloneInputValue(nativeNode, clonedNode)
     cloneSelectValue(nativeNode, clonedNode)
+    cloneScrollbarPositions(nativeNode, clonedNode)
   }
 
   return clonedNode


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Workaround for respecting scrollbar positions

### Motivation and Context

Fix #345 and #81. 
Just setting scrollLeft and scrollTop is not working, therefore this change simulate it by translate all children to the correct position and hide the scrollbars.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
