### PR TITLE
fix: Bug that changes content size when width and height are set to 'style' tag in canvas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,10 @@ export async function toCanvas<T extends HTMLElement>(
   }
   canvas.style.width = `${canvasWidth}`
   canvas.style.height = `${canvasHeight}`
+  canvas.setAttribute('width', `${canvasWidth}`)  
+  canvas.setAttribute('height', `${canvasHeight}`)
+  console.log(canvas)
+
 
   if (options.backgroundColor) {
     context.fillStyle = options.backgroundColor

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,10 +47,8 @@ export async function toCanvas<T extends HTMLElement>(
   }
   canvas.style.width = `${canvasWidth}`
   canvas.style.height = `${canvasHeight}`
-  canvas.setAttribute('width', `${canvasWidth}`)  
+  canvas.setAttribute('width', `${canvasWidth}`)
   canvas.setAttribute('height', `${canvasHeight}`)
-  console.log(canvas)
-
 
   if (options.backgroundColor) {
     context.fillStyle = options.backgroundColor


### PR DESCRIPTION
### Description

Width and height properties were set using the setAttribute method on canvas.

### Motivation and Context

- I have identified a problem with the image created by the ToCanvas feature on my device being set to different sizes
- Image size was not consistent when width, height, canvas width, and canvas height options were applied
- Motivated issue(personal project issue)[msdio/stackticon/issues/64]

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
