### PR TITLE
feat: Added fetchRequestInitGenerator option

### DIFF
--- a/src/dataurl.ts
+++ b/src/dataurl.ts
@@ -81,9 +81,12 @@ export async function resourceToDataURL(
 
   let dataURL: string
   try {
+    const requestInit = options.fetchRequestInit
+      ? options.fetchRequestInit
+      : options.fetchRequestInitGenerator?.(resourceUrl)
     const content = await fetchAsDataURL(
       resourceUrl,
-      options.fetchRequestInit,
+      requestInit,
       ({ res, result }) => {
         if (!contentType) {
           // eslint-disable-next-line no-param-reassign

--- a/src/embed-webfonts.ts
+++ b/src/embed-webfonts.ts
@@ -35,14 +35,13 @@ async function embedFonts(data: Metadata, options: Options): Promise<string> {
       url = new URL(url, data.url).href
     }
 
-    return fetchAsDataURL<[string, string]>(
-      url,
-      options.fetchRequestInit,
-      ({ result }) => {
-        cssText = cssText.replace(loc, `url(${result})`)
-        return [loc, result]
-      },
-    )
+    const requestInit = options.fetchRequestInit
+      ? options.fetchRequestInit
+      : options.fetchRequestInitGenerator?.(url)
+    return fetchAsDataURL<[string, string]>(url, requestInit, ({ result }) => {
+      cssText = cssText.replace(loc, `url(${result})`)
+      return [loc, result]
+    })
   })
 
   return Promise.all(loadFonts).then(() => cssText)

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,4 +91,12 @@ export interface Options {
    *
    */
   fetchRequestInit?: RequestInit
+
+  /**
+   * Function that generates a RequestInit based on a given URL.
+   * This function is intended to provide a convenient way to customize the RequestInit configuration for
+   * fetching the data from a specific URL.
+   *
+   */
+  fetchRequestInitGenerator?: (url: string) => RequestInit | undefined
 }

--- a/test/spec/options.spec.ts
+++ b/test/spec/options.spec.ts
@@ -173,4 +173,19 @@ describe('work with options', () => {
       .then(done)
       .catch(done)
   })
+
+  it('should support fetchRequestInitGenerator', (done) => {
+    bootstrap('images/node.html', 'images/style.css')
+      .then(
+        assertTextRendered(['PNG', 'JPG'], {
+          fetchRequestInitGenerator: (url: string) => {
+            return url.includes("/test")
+              ? { credentials: 'include' } as RequestInit
+              : undefined
+          },
+        }),
+      )
+      .then(done)
+      .catch(done)
+  })
 })


### PR DESCRIPTION
--

In scenarios where elements contain multiple URLs, including both internal and public links, there arises a need to supply distinct RequestInit configurations for various fetch requests.

Presently, the limitation lies in the fact that we can only provide a single fetchRequestInit, and this configuration is globally applied to all fetch calls for that element.

This proposed feature aims to enhance flexibility by enabling the provision of RequestInit configurations tailored to individual fetch requests based on their respective URLs. This enhancement ensures more granular control over the customization of fetch request behaviors, facilitating better handling of internal and public URLs.


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ X] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [X ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
