### PR TITLE
perf: svg cloning optimized using deep clone

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -61,17 +61,24 @@ async function cloneSingleNode<T extends HTMLElement>(
     return cloneIFrameElement(node)
   }
 
-  return node.cloneNode(false) as T
+  return node.cloneNode(isSVGElement(node)) as T
 }
 
 const isSlotElement = (node: HTMLElement): node is HTMLSlotElement =>
   node.tagName != null && node.tagName.toUpperCase() === 'SLOT'
+
+const isSVGElement = (node: HTMLElement): node is HTMLSlotElement =>
+  node.tagName != null && node.tagName.toUpperCase() === 'SVG'
 
 async function cloneChildren<T extends HTMLElement>(
   nativeNode: T,
   clonedNode: T,
   options: Options,
 ): Promise<T> {
+  if (isSVGElement(clonedNode)) {
+    return clonedNode
+  }
+
   let children: T[] = []
 
   if (isSlotElement(nativeNode) && nativeNode.assignedNodes) {
@@ -133,11 +140,11 @@ function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T) {
       ) {
         value = 'block'
       }
-      
+
       if (name === 'd' && clonedNode.getAttribute('d')) {
         value = `path(${clonedNode.getAttribute('d')})`
       }
-      
+
       targetStyle.setProperty(
         name,
         value,


### PR DESCRIPTION
Optimize cloning of SVG elements

### Description

Instead of cloning each child SVG element (which in my case is around 200) we can use cloneNode(true) to use deep clone mode

### Motivation and Context

Converting DIV with SVG inside taking around 20 second in Safari and around 15 in Chrome

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
