### PR TITLE
perf: embed only used fonts

### DIFF
--- a/test/resources/fonts/web-fonts/empty.html
+++ b/test/resources/fonts/web-fonts/empty.html
@@ -1,0 +1,1 @@
+<div style="font-family: Font1"></div>

--- a/test/spec/webfont.spec.ts
+++ b/test/spec/webfont.spec.ts
@@ -1,0 +1,107 @@
+import * as htmlToImage from '../../src'
+import { getSvgDocument } from './helper'
+
+describe('font embedding', () => {
+  describe('should embed only used fonts', () => {
+    it('should embed 1 font when use 1', async () => {
+      const root = document.createElement('div')
+      document.body.append(root)
+      try {
+        root.innerHTML = `
+          <style>
+              @font-face { 
+                  font-family: 'Font 0';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+              @font-face { 
+                  font-family: 'Font 1';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+              @font-face { 
+                  font-family: 'Font 2';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+          </style>
+          <p style="font-family: 'Font 1'">Hello world</p>
+        `
+        const svg = await htmlToImage.toSvg(root)
+        const doc = await getSvgDocument(svg)
+        const [style] = Array.from(doc.getElementsByTagName('style'))
+        expect(style.textContent).toContain('Font 1')
+        expect(style.textContent).not.toContain('Font 0')
+        expect(style.textContent).not.toContain('Font 2')
+      } finally {
+        root.remove()
+      }
+    })
+    it('should embed 2 fonts when use 2', async () => {
+      const root = document.createElement('div')
+      document.body.append(root)
+      try {
+        root.innerHTML = `
+          <style>
+              @font-face { 
+                  font-family: 'Font 0';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+              @font-face { 
+                  font-family: 'Font 1';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+              @font-face { 
+                  font-family: 'Font 2';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+          </style>
+          <p style="font-family: 'Font 0'">Hello world</p>
+          <p style="font-family: 'Font 2'">Hello world</p>
+        `
+        const svg = await htmlToImage.toSvg(root)
+        const doc = await getSvgDocument(svg)
+        const [style] = Array.from(doc.getElementsByTagName('style'))
+        expect(style.textContent).toContain('Font 0')
+        expect(style.textContent).toContain('Font 2')
+        expect(style.textContent).not.toContain('Font 1')
+      } finally {
+        root.remove()
+      }
+    })
+    it('should embed font used by deeply nested child', async () => {
+      const root = document.createElement('div')
+      document.body.append(root)
+      try {
+        root.innerHTML = `
+          <style>
+              @font-face { 
+                  font-family: 'Font 0';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+              @font-face { 
+                  font-family: 'Font 1';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+              @font-face { 
+                  font-family: 'Font 2';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+          </style>
+          <div>
+            <div>
+                <div>
+                    <div style="font-family: 'Font 1'">Hello world</div>
+                </div>
+            </div>
+          </div>
+        `
+        const svg = await htmlToImage.toSvg(root)
+        const doc = await getSvgDocument(svg)
+        const [style] = Array.from(doc.getElementsByTagName('style'))
+        expect(style.textContent).toContain('Font 1')
+        expect(style.textContent).not.toContain('Font 0')
+        expect(style.textContent).not.toContain('Font 2')
+      } finally {
+        root.remove()
+      }
+    })
+  })
+})


### PR DESCRIPTION
Optimized by embedding only the fonts that are actually used.

### Description

The document may have many fonts that are not used by the nodes to be processed. Currently, all fonts are embedded.

Added an optimization that recursively traverses the nodes to find the fonts that are used, then filters out the fonts that are not used before embedding them.

### Motivation and Context

This can significantly reduce processing time and the size of the SVG.

Resolves #405, resolves #389, resolves #310

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
