### PR TITLE
fix: fix a bug cannot read href attribute in use tags

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -214,7 +214,7 @@ async function ensureSVGSymbols<T extends HTMLElement>(
   for (let i = 0; i < uses.length; i++) {
     const use = uses[i]
     const id = use.getAttribute('href') ?? use.getAttribute('xlink:href')
-    if (!id) return
+    if (!id) continue
 
     const exist = clone.querySelector(id)
     const definition = document.querySelector(id) as HTMLElement

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -214,13 +214,13 @@ async function ensureSVGSymbols<T extends HTMLElement>(
   for (let i = 0; i < uses.length; i++) {
     const use = uses[i]
     const id = use.getAttribute('href') ?? use.getAttribute('xlink:href')
-    if (!id) continue
-
-    const exist = clone.querySelector(id)
-    const definition = document.querySelector(id) as HTMLElement
-    if (!exist && definition && !processedDefs[id]) {
-      // eslint-disable-next-line no-await-in-loop
-      processedDefs[id] = (await cloneNode(definition, options, true))!
+    if (id) {
+      const exist = clone.querySelector(id)
+      const definition = document.querySelector(id) as HTMLElement
+      if (!exist && definition && !processedDefs[id]) {
+        // eslint-disable-next-line no-await-in-loop
+        processedDefs[id] = (await cloneNode(definition, options, true))!
+      }
     }
   }
 

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -213,14 +213,14 @@ async function ensureSVGSymbols<T extends HTMLElement>(
   const processedDefs: { [key: string]: HTMLElement } = {}
   for (let i = 0; i < uses.length; i++) {
     const use = uses[i]
-    const id = use.getAttribute('xlink:href')
-    if (id) {
-      const exist = clone.querySelector(id)
-      const definition = document.querySelector(id) as HTMLElement
-      if (!exist && definition && !processedDefs[id]) {
-        // eslint-disable-next-line no-await-in-loop
-        processedDefs[id] = (await cloneNode(definition, options, true))!
-      }
+    const id = use.getAttribute('href') ?? use.getAttribute('xlink:href')
+    if (!id) return
+
+    const exist = clone.querySelector(id)
+    const definition = document.querySelector(id) as HTMLElement
+    if (!exist && definition && !processedDefs[id]) {
+      // eslint-disable-next-line no-await-in-loop
+      processedDefs[id] = (await cloneNode(definition, options, true))!
     }
   }
 


### PR DESCRIPTION
#392

### Description

Updated the attribute checking logic in `ensureSVGSymbols` to check `href` first, then fall back to `xlink:href`

```typescript
// Before
const id = use.getAttribute('xlink:href')

// After
const id = use.getAttribute('href') ?? use.getAttribute('xlink:href')
```


### Motivation and Context

The `ensureSVGSymbols` function was only checking the deprecated `xlink:href` attribute, causing some SVG assets to fail rendering. The function should check both `href` and `xlink:href` attributes to properly handle all SVG use cases.

- The `xlink:href` attribute is deprecated in SVG 2
- Modern SVG implementations use the standard `href` attribute
- This change maintains backwards compatibility while supporting current standards

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
