### PR TITLE
feat(disable-font-size-shrink): add optional flag to disable font size shrinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,13 @@ Defaults to `image/png`
 
 An array of style property names. Can be used to manually specify which style properties are included when cloning nodes. This can be useful for performance-critical scenarios.
 
+### skipFontSizeShrink
+
+When supplied, the library will skip the process of shrinking the font size.
+You may experience the text breaking on the last word.
+
+Defaults to `false`
+
 ## Browsers
 
 Only standard lib is currently used, but make sure your browser supports:

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -136,7 +136,11 @@ function cloneCSSStyle<T extends HTMLElement>(
   } else {
     getStyleProperties(options).forEach((name) => {
       let value = sourceStyle.getPropertyValue(name)
-      if (name === 'font-size' && value.endsWith('px')) {
+      if (
+        !options.skipFontSizeShrink &&
+        name === 'font-size' &&
+        value.endsWith('px')
+      ) {
         const reducedFont =
           Math.floor(parseFloat(value.substring(0, value.length - 2))) - 0.1
         value = `${reducedFont}px`

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,10 @@ export interface Options {
    * A string indicating the image format. The default type is image/png; that type is also used if the given type isn't supported.
    */
   type?: string
+  /**
+   * A boolean to turn off shrinking font size.
+   */
+  skipFontSizeShrink?: boolean
 
   /**
    *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->
This adds an optional property to the `Option` type that can disable the code that shrinks the font size. This resolves #415.

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [x] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
