### PR TITLE
fix(webfonts): support CSSGroupingRule

### DIFF
--- a/test/spec/webfont.spec.ts
+++ b/test/spec/webfont.spec.ts
@@ -9,15 +9,15 @@ describe('font embedding', () => {
       try {
         root.innerHTML = `
           <style>
-              @font-face { 
+              @font-face {
                   font-family: 'Font 0';
                   src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
               }
-              @font-face { 
+              @font-face {
                   font-family: 'Font 1';
                   src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
               }
-              @font-face { 
+              @font-face {
                   font-family: 'Font 2';
                   src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
               }
@@ -40,15 +40,15 @@ describe('font embedding', () => {
       try {
         root.innerHTML = `
           <style>
-              @font-face { 
+              @font-face {
                   font-family: 'Font 0';
                   src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
               }
-              @font-face { 
+              @font-face {
                   font-family: 'Font 1';
                   src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
               }
-              @font-face { 
+              @font-face {
                   font-family: 'Font 2';
                   src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
               }
@@ -72,15 +72,15 @@ describe('font embedding', () => {
       try {
         root.innerHTML = `
           <style>
-              @font-face { 
+              @font-face {
                   font-family: 'Font 0';
                   src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
               }
-              @font-face { 
+              @font-face {
                   font-family: 'Font 1';
                   src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
               }
-              @font-face { 
+              @font-face {
                   font-family: 'Font 2';
                   src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
               }
@@ -99,6 +99,53 @@ describe('font embedding', () => {
         expect(style.textContent).toContain('Font 1')
         expect(style.textContent).not.toContain('Font 0')
         expect(style.textContent).not.toContain('Font 2')
+      } finally {
+        root.remove()
+      }
+    })
+    it('should embed font defined in CSS grouping rule', async () => {
+      const root = document.createElement('div')
+      document.body.append(root)
+      try {
+        root.innerHTML = `
+          <style>
+              @layer layer1;
+
+              @layer layer1 {
+                @font-face {
+                  font-family: 'Font 0';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+                }
+              }
+
+              @media screen {
+                @font-face {
+                  font-family: 'Font 1';
+                  src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+                }
+              }
+
+              @font-face {
+                font-family: 'Font 2';
+                src: url('https://fonts.gstatic.com/s/roboto/v30/KFOmCnqEu92Fr1Mu72xKKTU1Kvnz.woff2');
+              }
+          </style>
+          <p style="font-family: 'Font 0'">Hello world</p>
+          <p style="font-family: 'Font 1'">Hello world</p>
+        `
+        const svg = await htmlToImage.toSvg(root)
+        const doc = await getSvgDocument(svg)
+        const [style] = Array.from(doc.getElementsByTagName('style'))
+
+        expect(style.textContent).toContain(
+          'font-family: "Font 0"; src: url("data:application/font-woff;base64,',
+        )
+        expect(style.textContent).toContain(
+          'font-family: "Font 1"; src: url("data:application/font-woff;base64,',
+        )
+        expect(style.textContent).not.toContain(
+          'font-family: "Font 2"; src: url("data:application/font-woff;base64,',
+        )
       } finally {
         root.remove()
       }


### PR DESCRIPTION
This allows @font-face defined in @layer rules.

### Description

@font-face rules were not properly inlined if they were defined in an `@layer` rule, or any type of CSSGroupingRule.

### Motivation and Context

CSS layers are a relatively new feature, but the popular tailwind uses it at its core. The font definitions in such a layer were stripped from the resulting image, leading to broken styles.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
