### PR TITLE
fix(createImage): make waiting on animation frame optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,13 @@ You may experience loss of parts of the image if set to `true` and you are expor
 
 Defaults to `false`  
 
+### waitForAnimationFrameAcquired
+
+When supplied, the library will wait for the next animation frame to be acquired before rendering the image.
+This is useful when you want to achieve a smooth transition when rendering the image.
+
+Defaults to `false`
+
 ### type
 
 A string indicating the image format. The default type is image/png; that type is also used if the given type isn't supported.

--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -9,12 +9,12 @@ import {
 import { getMimeType } from './mimes'
 import { resourceToDataURL } from './dataurl'
 
-async function cloneCanvasElement(canvas: HTMLCanvasElement) {
+async function cloneCanvasElement(canvas: HTMLCanvasElement, options: Options) {
   const dataURL = canvas.toDataURL()
   if (dataURL === 'data:,') {
     return canvas.cloneNode(false) as HTMLCanvasElement
   }
-  return createImage(dataURL)
+  return createImage(dataURL, options)
 }
 
 async function cloneVideoElement(video: HTMLVideoElement, options: Options) {
@@ -25,13 +25,13 @@ async function cloneVideoElement(video: HTMLVideoElement, options: Options) {
     canvas.height = video.clientHeight
     ctx?.drawImage(video, 0, 0, canvas.width, canvas.height)
     const dataURL = canvas.toDataURL()
-    return createImage(dataURL)
+    return createImage(dataURL, options)
   }
 
   const poster = video.poster
   const contentType = getMimeType(poster)
   const dataURL = await resourceToDataURL(poster, contentType, options)
-  return createImage(dataURL)
+  return createImage(dataURL, options)
 }
 
 async function cloneIFrameElement(iframe: HTMLIFrameElement, options: Options) {
@@ -55,7 +55,7 @@ async function cloneSingleNode<T extends HTMLElement>(
   options: Options,
 ): Promise<HTMLElement> {
   if (isInstanceOfElement(node, HTMLCanvasElement)) {
-    return cloneCanvasElement(node)
+    return cloneCanvasElement(node, options)
   }
 
   if (isInstanceOfElement(node, HTMLVideoElement)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export async function toCanvas<T extends HTMLElement>(
 ): Promise<HTMLCanvasElement> {
   const { width, height } = getImageSize(node, options)
   const svg = await toSvg(node, options)
-  const img = await createImage(svg)
+  const img = await createImage(svg, options)
 
   const canvas = document.createElement('canvas')
   const context = canvas.getContext('2d')!

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,11 @@ export interface Options {
    */
   skipAutoScale?: boolean
   /**
+   * An option for rendering the image only when the image is visible on the frame.
+   * This might be useful for performance reasons when rendering a large number of images.
+   */
+  waitForAnimationFrameAcquired?: boolean
+  /**
    * A string indicating the image format. The default type is image/png; that type is also used if the given type isn't supported.
    */
   type?: string

--- a/src/util.ts
+++ b/src/util.ts
@@ -196,12 +196,19 @@ export function canvasToBlob(
   })
 }
 
-export function createImage(url: string): Promise<HTMLImageElement> {
+export function createImage(
+  url: string,
+  options: Options = {},
+): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image()
     img.onload = () => {
       img.decode().then(() => {
-        requestAnimationFrame(() => resolve(img))
+        if (options.waitForAnimationFrameAcquired) {
+          requestAnimationFrame(() => resolve(img))
+        } else {
+          resolve(img)
+        }
       })
     }
     img.onerror = reject


### PR DESCRIPTION
Added configuration property waitForAnimationFrameAcquired. Default value is false.

Closes #502

BREAKING CHANGE:
 Waiting on animation frame was default behaviour since version 1.11.12. If you rely on this feature, explicitly set waitForAnimationFrameAcquired to true.

<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
