### PR TITLE
fix(firefox): font might be undefined

### DIFF
--- a/src/embed-webfonts.ts
+++ b/src/embed-webfonts.ts
@@ -203,7 +203,7 @@ async function parseWebFontRules<T extends HTMLElement>(
 }
 
 function normalizeFontFamily(font: string) {
-  return font.trim().replace(/["']/g, '')
+  return font?.trim().replace(/["']/g, '')
 }
 
 function getUsedFonts(node: HTMLElement) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Fix an issue on Firefox only where sometimes the font can be undefined after split.

### Motivation and Context

It breaks the whole screenshot process and fails to download in Firefox because of undefined font.

![Capture d'écran 2025-06-25 114950](https://github.com/user-attachments/assets/d6726e92-609c-4b44-ac65-fecfa8b4e109)

```js
const fontFamily = node.style.fontFamily || getComputedStyle(node).fontFamily;
console.log("----", fontFamily, typeof fontFamily);

AND

console.log(font, typeof font);
return font.trim().replace(/["']/g, '');
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
