### PR TITLE
fix(toPixelData): Correct width and height per pixelRatio

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export async function toPixelData<T extends HTMLElement>(
   const { width, height } = getImageSize(node, options)
   const canvas = await toCanvas(node, options)
   const ctx = canvas.getContext('2d')!
-  return ctx.getImageData(0, 0, width, height).data
+  return ctx.getImageData(0, 0, canvas.width, canvas.height).data
 }
 
 export async function toPng<T extends HTMLElement>(


### PR DESCRIPTION
Before this commit, toPixelData when used with pixelRatio would fail to get the correct image size and would only get half of it for example when using pixelRatio of 2 (default of hd screens I believe).

Fixes #276
