### PR TITLE
fix(532): fontFamily get on css rules

### DIFF
--- a/src/embed-webfonts.ts
+++ b/src/embed-webfonts.ts
@@ -234,7 +234,11 @@ export async function getWebFontCSS<T extends HTMLElement>(
   const cssTexts = await Promise.all(
     rules
       .filter((rule) =>
-        usedFonts.has(normalizeFontFamily(rule.style.fontFamily)),
+        usedFonts.has(
+          normalizeFontFamily(
+            rule.style.fontFamily || rule.style.getPropertyValue('fontFamily'),
+          ),
+        ),
       )
       .map((rule) => {
         const baseUrl = rule.parentStyleSheet


### PR DESCRIPTION
Fixes https://github.com/bubkoo/html-to-image/issues/532

### Description

`fontFamily` may not be accessible on rules directly (seen that on Firefox). 
Relying on `getPropertyValue` ensure it's properly parsed on every browser.

### Motivation and Context

Currently crashing:
```
oops, something went wrong! TypeError: can't access property "trim", t is undefined
```

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/bubkoo/html-to-image/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
