### PR TITLE
fix: resolve CSS custom properties (var()) in SVG descendants

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -80,7 +80,23 @@ async function cloneChildren<T extends HTMLElement>(
   clonedNode: T,
   options: Options,
 ): Promise<T> {
-  if (isSVGElement(clonedNode)) {
+  if (isSVGElement(nativeNode)) {
+    // SVG was deep-cloned for performance, but CSS custom properties (var())
+    // defined in external stylesheets won't be available in the exported image.
+    // We resolve them by copying getComputedStyle() values — which resolves
+    // var() to their actual computed values — onto each cloned descendant.
+    const nativeDescendants = Array.from(
+      nativeNode.querySelectorAll<HTMLElement>('*'),
+    )
+    const clonedDescendants = Array.from(
+      clonedNode.querySelectorAll<HTMLElement>('*'),
+    )
+    nativeDescendants.forEach((native, i) => {
+      const cloned = clonedDescendants[i]
+      if (cloned) {
+        cloneCSSStyle(native, cloned, options)
+      }
+    })
     return clonedNode
   }
 

--- a/test/resources/svg-css-var/node.html
+++ b/test/resources/svg-css-var/node.html
@@ -1,0 +1,9 @@
+<svg
+  id="svg-css-var-test"
+  width="100"
+  height="100"
+  viewBox="0 0 100 100"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect class="var-rect" x="10" y="10" width="80" height="80" />
+</svg>

--- a/test/resources/svg-css-var/style.css
+++ b/test/resources/svg-css-var/style.css
@@ -1,0 +1,12 @@
+#dom-node {
+  width: 100px;
+  overflow: hidden;
+}
+
+:root {
+  --rect-fill: rgb(0, 128, 0);
+}
+
+.var-rect {
+  fill: var(--rect-fill);
+}

--- a/test/spec/svg.spec.ts
+++ b/test/spec/svg.spec.ts
@@ -57,4 +57,23 @@ describe('work with svg element', () => {
       .then(done)
       .catch(done)
   })
+
+  it('should resolve CSS custom properties (var()) in SVG descendants', (done) => {
+    // Regression test for: SVG deep-clone skips cloneCSSStyle for descendants,
+    // leaving CSS var() unresolved in exported image.
+    // Fix in clone-node.ts: walk native/cloned descendant pairs, call cloneCSSStyle.
+    bootstrap('svg-css-var/node.html', 'svg-css-var/style.css')
+      .then(toSvg)
+      .then(getSvgDocument)
+      .then((doc) => {
+        const rect = doc.querySelector('.var-rect') as SVGRectElement | null
+        expect(rect).not.toBeNull()
+        // After the fix, cloneCSSStyle copies computed styles onto the cloned rect.
+        // The serialized SVG must NOT contain an unresolved var() reference.
+        const inlineStyle = rect?.getAttribute('style') ?? ''
+        expect(inlineStyle).not.toContain('var(')
+      })
+      .then(done)
+      .catch(done)
+  })
 })

--- a/test/spec/svg.spec.ts
+++ b/test/spec/svg.spec.ts
@@ -62,6 +62,9 @@ describe('work with svg element', () => {
     // Regression test for: SVG deep-clone skips cloneCSSStyle for descendants,
     // leaving CSS var() unresolved in exported image.
     // Fix in clone-node.ts: walk native/cloned descendant pairs, call cloneCSSStyle.
+    // The CSS defines: :root { --rect-fill: rgb(0, 128, 0); } and .var-rect { fill: var(--rect-fill); }
+    // Without the fix: the cloned rect has no inline style (deep-clone skips descendants).
+    // With the fix: the cloned rect has fill: rgb(0, 128, 0) as an inline style.
     bootstrap('svg-css-var/node.html', 'svg-css-var/style.css')
       .then(toSvg)
       .then(getSvgDocument)
@@ -69,9 +72,12 @@ describe('work with svg element', () => {
         const rect = doc.querySelector('.var-rect') as SVGRectElement | null
         expect(rect).not.toBeNull()
         // After the fix, cloneCSSStyle copies computed styles onto the cloned rect.
-        // The serialized SVG must NOT contain an unresolved var() reference.
+        // The inline style must contain a resolved fill color (not a var() reference).
         const inlineStyle = rect?.getAttribute('style') ?? ''
         expect(inlineStyle).not.toContain('var(')
+        // Positive assertion: the fill property must be present and resolved to rgb(0, 128, 0).
+        // This fails without the fix (style would be empty since descendants are skipped).
+        expect(inlineStyle).toMatch(/fill\s*:\s*rgb\(\s*0\s*,\s*128\s*,\s*0\s*\)/)
       })
       .then(done)
       .catch(done)


### PR DESCRIPTION
## Problem

Since v1.11.12, CSS custom properties (`var()`) defined in external stylesheets no longer appear in exported images when used inside SVG elements (e.g., Recharts with MUI theme colors).

**Root cause:** PR #462 introduced a performance optimization that deep-clones SVG elements using `cloneNode(true)`. The early return added to `cloneChildren` for SVG nodes means `cloneCSSStyle()` is **never called on SVG child elements**. Since `cloneCSSStyle` uses `window.getComputedStyle()` to resolve `var()` references to their actual values, skipping it leaves CSS variables unresolved. When the SVG is serialized, those variable definitions are unavailable in the export context, so colors render as empty/transparent.

Reproducible example: https://codesandbox.io/p/sandbox/vq6ml5

Fixes #500

## Solution

After deep-cloning the SVG, iterate over all native/cloned descendant pairs and call `cloneCSSStyle()` on each. `getComputedStyle()` resolves `var(--name)` to its actual computed value, which then gets inlined on the cloned element.

This preserves the performance benefit of the deep-clone optimization (no async per-child `cloneNode` calls for the SVG subtree) while correctly resolving CSS variables.

## Why not PR #521?

PR #521 simply removes the early return for SVG elements, which causes SVG children to be **re-appended** to an already-populated deep-cloned SVG, resulting in duplicate children. This fix avoids that by only copying styles, not re-cloning the subtree.

## Changes

- `src/clone-node.ts`: 17 lines changed in `cloneChildren`