### PR TITLE
fix: prevent iframe content from being cloned twice

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -88,11 +88,11 @@ async function cloneChildren<T extends HTMLElement>(
 
   if (isSlotElement(nativeNode) && nativeNode.assignedNodes) {
     children = toArray<T>(nativeNode.assignedNodes())
-  } else if (
-    isInstanceOfElement(nativeNode, HTMLIFrameElement) &&
-    nativeNode.contentDocument?.body
-  ) {
-    children = toArray<T>(nativeNode.contentDocument.body.childNodes)
+  } else if (isInstanceOfElement(nativeNode, HTMLIFrameElement)) {
+    // cloneIFrameElement (called by cloneSingleNode) already recursively clones
+    // the iframe's contentDocument.body and all its descendants.
+    // Appending children here would duplicate the iframe content.
+    return clonedNode
   } else {
     children = toArray<T>((nativeNode.shadowRoot ?? nativeNode).childNodes)
   }

--- a/test/resources/iframe-content/node.html
+++ b/test/resources/iframe-content/node.html
@@ -1,0 +1,7 @@
+<div id="iframe-wrapper" style="width:200px;height:80px;">
+  <iframe
+    id="test-iframe"
+    style="width:100%;height:100%;border:none;"
+    srcdoc="<html><body><p class='iframe-para' data-testid='iframe-para'>IFRAME_CONTENT</p></body></html>"
+  ></iframe>
+</div>

--- a/test/resources/iframe-content/node.html
+++ b/test/resources/iframe-content/node.html
@@ -1,7 +1,8 @@
 <div id="iframe-wrapper" style="width:200px;height:80px;">
   <iframe
     id="test-iframe"
+    title="Test iframe content"
     style="width:100%;height:100%;border:none;"
-    srcdoc="<html><body><p class='iframe-para' data-testid='iframe-para'>IFRAME_CONTENT</p></body></html>"
+    srcdoc="<!DOCTYPE html><html lang='en'><head><title>iframe test</title></head><body><p class='iframe-para' data-testid='iframe-para'>IFRAME_CONTENT</p></body></html>"
   ></iframe>
 </div>

--- a/test/spec/special.spec.ts
+++ b/test/spec/special.spec.ts
@@ -2,6 +2,7 @@
 
 import '../spec/setup'
 import { toPng } from '../../src'
+import { cloneNode } from '../../src/clone-node'
 import { delay } from '../../src/util'
 import { assertTextRendered, bootstrap, renderAndCheck } from '../spec/helper'
 
@@ -56,6 +57,43 @@ describe('special cases', () => {
   it('should caputre lazy loading images', (done) => {
     bootstrap('images/loading.html', 'images/style.css')
       .then(assertTextRendered(['PNG', 'JPG']))
+      .then(done)
+      .catch(done)
+  })
+
+  it('should not duplicate iframe content when cloning', (done) => {
+    // Regression test for: cloneChildren() re-appended iframe body childNodes
+    // after cloneSingleNode() → cloneIFrameElement() had already recursively
+    // cloned the full iframe body, causing every child to appear twice.
+    bootstrap('iframe-content/node.html')
+      .then((node) => {
+        const iframe = node.querySelector('iframe') as HTMLIFrameElement
+        // Poll until srcdoc iframe body is accessible (async load)
+        return new Promise<HTMLDivElement>((resolve, reject) => {
+          let attempts = 0
+          const poll = () => {
+            attempts++
+            const ready =
+              iframe.contentDocument?.body?.querySelector('.iframe-para')
+            if (ready) {
+              resolve(node)
+            } else if (attempts > 30) {
+              reject(new Error('iframe did not load in time'))
+            } else {
+              setTimeout(poll, 100)
+            }
+          }
+          poll()
+        })
+      })
+      .then((node) => cloneNode(node, {}, true))
+      .then((clonedNode) => {
+        expect(clonedNode).not.toBeNull()
+        // With the bug: two .iframe-para elements appear (duplicate children).
+        // With the fix: exactly one .iframe-para appears.
+        const paras = clonedNode!.querySelectorAll('.iframe-para')
+        expect(paras.length).toBe(1)
+      })
       .then(done)
       .catch(done)
   })


### PR DESCRIPTION
## Problem

Closes #543

When cloning a node that contains an `<iframe>`, the iframe content was duplicated in the output.

### Root cause

`cloneNode` runs:
1. `cloneSingleNode(iframe)` → calls `cloneIFrameElement` → **recursively clones the full `contentDocument.body`** (including all descendants)
2. `cloneChildren(iframe, clonedBody)` → finds `isInstanceOfElement(nativeNode, HTMLIFrameElement)` is true → **appends `contentDocument.body.childNodes` again**

Every child of the iframe body therefore appears twice in the cloned output.

## Fix

Return early from `cloneChildren` when the native node is an `HTMLIFrameElement`.

```ts
} else if (isInstanceOfElement(nativeNode, HTMLIFrameElement)) {
  // cloneIFrameElement already recursively cloned the full body; skip.
  return clonedNode
}
```

## Test

Added regression test in `test/spec/special.spec.ts`:
- Bootstraps a fixture with an `<iframe srcdoc="...">` containing a `.iframe-para` element
- Polls until the iframe body is accessible, then calls `cloneNode` directly
- Asserts that `.iframe-para` appears **exactly once** in the cloned tree (would be 2 without the fix)