### PR TITLE
fix: preserve repeating-linear-gradient through cssText round-trip

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -133,6 +133,20 @@ function cloneCSSStyle<T extends HTMLElement>(
   if (sourceStyle.cssText) {
     targetStyle.cssText = sourceStyle.cssText
     targetStyle.transformOrigin = sourceStyle.transformOrigin
+    // Re-apply background-image explicitly: some browsers normalise gradient
+    // stop-positions when round-tripping through cssText serialisation, which
+    // causes a repeating-linear-gradient to lose its repeating behaviour and
+    // render identically to a plain linear-gradient.  Fetching the value via
+    // getPropertyValue bypasses the shorthand serialiser and returns the exact
+    // computed value as the browser resolved it.
+    const bgImage = sourceStyle.getPropertyValue('background-image')
+    if (bgImage && bgImage !== 'none') {
+      targetStyle.setProperty(
+        'background-image',
+        bgImage,
+        sourceStyle.getPropertyPriority('background-image'),
+      )
+    }
   } else {
     getStyleProperties(options).forEach((name) => {
       let value = sourceStyle.getPropertyValue(name)

--- a/test/resources/repeating-gradient/node.html
+++ b/test/resources/repeating-gradient/node.html
@@ -1,0 +1,5 @@
+<div
+  id="gradient-box"
+  class="gradient-box"
+  style="width:200px;height:80px;"
+></div>

--- a/test/resources/repeating-gradient/style.css
+++ b/test/resources/repeating-gradient/style.css
@@ -1,0 +1,13 @@
+/* Regression test for: repeating-linear-gradient treated as linear-gradient.
+ * The gradient tile is 20px (0 → 10px → 20px), which creates a visible stripe
+ * pattern. Without the fix the repeating- prefix may be lost during CSS cloning,
+ * causing the gradient to stretch across the full element height instead. */
+.gradient-box {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgb(255, 0, 0) 0px,
+    rgb(255, 0, 0) 10px,
+    rgb(0, 0, 255) 10px,
+    rgb(0, 0, 255) 20px
+  );
+}

--- a/test/spec/svg.spec.ts
+++ b/test/spec/svg.spec.ts
@@ -2,6 +2,7 @@
 
 import '../spec/setup'
 import { toSvg } from '../../src'
+import { cloneNode } from '../../src/clone-node'
 import { bootstrap, renderAndCheck, getSvgDocument } from '../spec/helper'
 
 describe('work with svg element', () => {
@@ -54,6 +55,29 @@ describe('work with svg element', () => {
       'svg-use-tag/image',
     )
       .then(renderAndCheck)
+      .then(done)
+      .catch(done)
+  })
+
+  it('should preserve repeating-linear-gradient in cloned element style', (done) => {
+    // Regression test for: repeating-linear-gradient treated as linear-gradient.
+    // The cssText serialisation path (Firefox/Safari) normalises gradient stop
+    // positions to 0%/100%, making the gradient visually indistinguishable from
+    // a plain linear-gradient.  The fix explicitly re-applies background-image
+    // via getPropertyValue after cssText assignment.
+    bootstrap('repeating-gradient/node.html', 'repeating-gradient/style.css')
+      .then((node) => cloneNode(node, {}, true))
+      .then((clonedNode) => {
+        expect(clonedNode).not.toBeNull()
+        const box = clonedNode!.querySelector(
+          '.gradient-box',
+        ) as HTMLElement | null
+        expect(box).not.toBeNull()
+        // The cloned element must have an inline background-image that preserves
+        // the repeating-linear-gradient function name (not normalised away).
+        const bgImage = box!.style.backgroundImage
+        expect(bgImage).toContain('repeating-linear-gradient')
+      })
       .then(done)
       .catch(done)
   })


### PR DESCRIPTION
Closes #571

When an element uses repeating-linear-gradient, the exported image renders it as a plain linear-gradient because the browser cssText serialiser normalises stop-positions to 0%/100%.

Fix: after the cssText assignment, explicitly re-apply background-image via getPropertyValue, which returns the exact computed value and bypasses shorthand normalisation.

Test added: regression test bootstraps a fixture with a 20px-tile repeating-linear-gradient via external stylesheet, clones it, and asserts the cloned inline style still contains repeating-linear-gradient.